### PR TITLE
Upgraded to codecov v5

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 					"pytest",
 					"Redis",
 					"testdb"
-				],				
+				],	
 				"[python]": {
 					"editor.defaultFormatter": "ms-python.black-formatter",
 					"editor.formatOnSave": true
@@ -50,12 +50,12 @@
 				"tamasfe.even-better-toml",
 				"donjayamanne.githistory",
 				"GitHub.vscode-pull-request-github",
+				"github.vscode-github-actions",
 				"hbenl.vscode-test-explorer",
 				"LittleFoxTeam.vscode-python-test-adapter",
 				"redhat.vscode-yaml",
 				"unjinjang.rest-api-client",
 				"ms-azuretools.vscode-docker",
-				"github.vscode-github-actions",
 				"streetsidesoftware.code-spell-checker",				
 				"bbenoist.vagrant"
 			]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
       # Label used to access the service container
       redis:
         # Docker Hub image
-        image: redis
+        image: redis:6-alpine
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"
@@ -45,14 +45,20 @@ jobs:
           pylint service tests --max-line-length=127
 
       - name: Run unit tests with PyTest
-        run: pytest --pspec --cov=service --cov-report=xml --cov-fail-under=95
+        run: pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml
         env:
           DATABASE_URI: "redis://redis:6379"
 
+      ######################################################################
       # Create a CODECOV_TOKEN in Settings->Secrets and variables->Actions
       # and then uncomment the CodeCov action during hands-on lab
+      ######################################################################
 
-      # - name: Upload coverage reports to Codecov
-      #   uses: codecov/codecov-action@v3.1.4
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }} 
+      - name: Install packages for Codecov to work
+        run: apt-get update && apt-get install -y git curl gpg
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: nyu-devops/lab-github-actions


### PR DESCRIPTION
Made the following changes:

- Updated the GitHub Action `workflow.yaml` to install `git` `curl` and `gpg` as prerequisites for Codecov v5
- Updated the GitHub Action `workflow.yaml` to use `codecov@v5`
- Updated the GitHub Action `workflow.yaml` to use `redis:6-alpine` as the database instead of just `redis`
- Updated the GitHub Action `workflow.yaml` to use the `slug` parameter which is now required